### PR TITLE
feat: Add missing 'Home' link to mobile navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,6 +27,7 @@
                     <a href="#features" class="text-gray-600 hover:text-emerald-600 w-full text-right md:w-auto md:text-left px-3 py-1 md:py-2 rounded-md text-sm font-medium">Features</a>
                     <a href="privacy.html" class="text-gray-600 hover:text-emerald-600 w-full text-right md:w-auto md:text-left px-3 py-1 md:py-2 rounded-md text-sm font-medium">Privacy</a>
                     <a href="https://github.com/SnipScreen/SnipScreen-Tracker/issues" target="_blank" rel="noopener noreferrer" class="text-gray-600 hover:text-emerald-600 w-full text-right md:w-auto md:text-left px-3 py-1 md:py-2 rounded-md text-sm font-medium">Feedback/Support</a>
+                    <a href="index.html" class="text-gray-600 hover:text-emerald-600 w-full text-right md:w-auto md:text-left px-3 py-1 md:py-2 rounded-md text-sm font-medium md:hidden">Home</a>
                 </div>
             </div>
         </nav>


### PR DESCRIPTION
The navigation header in `index.html` was missing a 'Home' link for mobile viewports. This created an inconsistency with the navigation on the `privacy.html` page and a usability issue for mobile users.

This change adds the 'Home' link to the navigation bar in `index.html`, making it consistent with the rest of the site. The link is only visible on mobile screens, matching the behavior of the corresponding link on the privacy page.